### PR TITLE
Use httpx for automatic SSL certificate handling

### DIFF
--- a/gha_tools/action_updater.py
+++ b/gha_tools/action_updater.py
@@ -9,7 +9,8 @@ from enum import Enum
 from functools import cached_property, lru_cache, partial
 from pathlib import Path
 from typing import Iterable
-from urllib.error import HTTPError
+
+import httpx
 
 from gha_tools.github_api import get_github_json
 
@@ -82,8 +83,8 @@ class ActionVersions:
         log.debug("Fetching versions for %s...", action_name)
         try:
             action_tags = get_github_json(f"https://api.github.com/repos/{action_name}/tags")
-        except HTTPError as he:
-            if he.status == 404:
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
                 log.warning("Action %s (or tags for it) not found.", action_name)
                 return cls(name=action_name, all_version_infos=[])
             raise

--- a/gha_tools/github_api.py
+++ b/gha_tools/github_api.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-import base64
-import json
 import os
-import urllib.request
 from typing import Any
-from urllib.error import HTTPError
+
+import httpx
 
 from gha_tools.__about__ import __version__
 
@@ -18,24 +16,25 @@ def get_github_json(url: str) -> Any:
         raise ValueError("URL must be a GitHub API URL")
     if cache is not None and url in cache:
         return cache[url]
-    request = urllib.request.Request(
-        url,
-        headers={
-            "Accept": "application/vnd.github.v3+json",
-            "User-Agent": f"gha-tools/{__version__} (@akx)",
-        },
-    )
-    if auth := (os.environ.get("GITHUB_AUTH") or os.environ.get("GITHUB_TOKEN")):
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+        "User-Agent": f"gha-tools/{__version__} (@akx)",
+    }
+
+    auth = os.environ.get("GITHUB_AUTH") or os.environ.get("GITHUB_TOKEN")
+    auth_tuple: tuple[str, str] | None = None
+    if auth:
         if ":" in auth:
-            auth = base64.b64encode(auth.encode("utf-8")).decode("utf-8")
-            request.add_header("Authorization", f"Basic {auth}")
+            username, password = auth.split(":", 1)
+            auth_tuple = (username, password)
         else:
-            request.add_header("Authorization", f"Bearer {auth}")
-    with urllib.request.urlopen(request) as f:
-        content = f.read().decode("utf-8", "replace")
-        if f.status != 200:
-            raise HTTPError(url, f.status, f.reason, f.headers, None)
-    data = json.loads(content)
+            headers["Authorization"] = f"Bearer {auth}"
+
+    with httpx.Client() as client:
+        response = client.get(url, headers=headers, auth=auth_tuple, follow_redirects=True)
+        response.raise_for_status()
+        data = response.json()
+
     if cache is not None:
         cache[url] = data
     return data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
+    "httpx>=0.27.0",
     "click>=7",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
*This PR was created with assistance from Claude 4.5 opus-high in Cursor.*

---

Fixes #9

## Summary

Replace `urllib.request` with `httpx` to fix SSL certificate errors on NixOS.

## Changes

- Replace `urllib.request` with `httpx` in `github_api.py`
- Update exception handling from `urllib.error.HTTPError` to `httpx.HTTPStatusError` in `action_updater.py`
- Add `httpx>=0.27.0` dependency

## Why httpx?

`httpx` automatically handles SSL certificates:
- Respects `SSL_CERT_FILE` if set and valid
- Falls back to `certifi`'s certificate bundle otherwise

This makes `gha-tools` work out of the box on NixOS without manual workarounds.

## Testing

- All existing tests pass
- Manually tested on NixOS with CausalPy repository